### PR TITLE
feature/updated-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Clone the branch that has the experimental version of docker along with rexray i
 ```
 - git clone -b docker_1.7rc3_experimental_rexray https://github.com/emccode/vagrant-puppet-scaleio.git
 - cd vagrant-puppet-scaleio
+- vagrant plugin install vagrant-hosts vagrant-hostmanager vagrant-auto_network
 - vagrant up
 - vagrant ssh mdm1
 - sudo su


### PR DESCRIPTION
Updated Readme
    
This patch updates the Readme to reflect the need for installing the Vagrant plug-ins vagrant-hosts, vagrant-hostmanager, and vagrant-auto_network.